### PR TITLE
Enable initial support for SPI1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ OPTIMIZEFLAGS+=-Os
 else ifdef PIC32MZ_EF_STARTERKIT
 EMBEDDED=1
 BOARD=PIC32MZ_EF_STARTERKIT
-OPTIMIZEFLAGS+=-O2
+OPTIMIZEFLAGS+=-O1
 MPLABXC32=1
 PIC32MZ_EF_SK_USART=1
 XC32PROCESSOR=32MZ2048EFM144
@@ -1373,19 +1373,21 @@ INCLUDE +=                                      \
   -I./targets/pic32mzef \
   -I./targets/pic32mzef/framework \
   -I./targets/pic32mzef/framework/system/clk \
-  -I./targets/pic32mzef/framework/driver/usart
+  -I./targets/pic32mzef/framework/driver/usart \
+  -I./targets/pic32mzef/framework/driver/spi
 OPTIMIZEFLAGS += -O1 -fno-common -fno-exceptions -fdata-sections -ffunction-sections
 SOURCES +=                                                                     \
   targets/pic32mzef/main.c                                                     \
   targets/pic32mzef/jshardware.c                                               \
-	targets/pic32mzef/system_init.c \
-	targets/pic32mzef/framework/system/clk/src/sys_clk_static.c \
-	targets/pic32mzef/framework/system/ports/src/sys_ports_static.c \
-	targets/pic32mzef/framework/driver/usart/drv_usart_static.c \
-	$(MICROCHIP_HARMONY_PATH)/framework/system/devcon/src/sys_devcon.c \
-$(MICROCHIP_HARMONY_PATH)/framework/system/devcon/src/sys_devcon_pic32mz.c \
-$(MICROCHIP_HARMONY_PATH)/bsp/pic32mz_ef_sk/bsp_sys_init.c \
-$(MICROCHIP_HARMONY_PATH)/framework/system/int/src/sys_int_pic32.c
+  targets/pic32mzef/system_init.c \
+  targets/pic32mzef/framework/system/clk/src/sys_clk_static.c \
+  targets/pic32mzef/framework/system/ports/src/sys_ports_static.c \
+  targets/pic32mzef/framework/driver/usart/drv_usart_static.c \
+  targets/pic32mzef/framework/driver/spi/drv_spi_static.c \
+  $(MICROCHIP_HARMONY_PATH)/framework/system/devcon/src/sys_devcon.c \
+  $(MICROCHIP_HARMONY_PATH)/framework/system/devcon/src/sys_devcon_pic32mz.c \
+  $(MICROCHIP_HARMONY_PATH)/bsp/pic32mz_ef_sk/bsp_sys_init.c \
+  $(MICROCHIP_HARMONY_PATH)/framework/system/int/src/sys_int_pic32.c
 LDFLAGS += -g -O1 -mdebugger -Wl,--defsym=_DEBUGGER=1 \
   -Wl,--defsym=_min_stack_size=0x8000,--defsym=_min_heap_size=0x2000 \
   -Wl,--report-mem -mreserve=data@0x0:0x37F \

--- a/boards/PIC32MZ_EF_STARTERKIT.py
+++ b/boards/PIC32MZ_EF_STARTERKIT.py
@@ -48,15 +48,18 @@ devices = {
 };
 
 def get_pins():
-    pins = [
-        { "name":"PH0", "sortingname":"H0", "port":"H", "num":"0", "functions":{}, "csv":{} },
-        { "name":"PH1", "sortingname":"H1", "port":"H", "num":"1", "functions":{}, "csv":{} },
-        { "name":"PH2", "sortingname":"H2", "port":"H", "num":"2", "functions":{}, "csv":{} },
-        { "name":"PB12", "sortingname":"B12", "port":"B", "num":"12", "functions":{}, "csv":{} },
-        { "name":"PB13", "sortingname":"B13", "port":"B", "num":"13", "functions":{}, "csv":{} },
-        { "name":"PB14", "sortingname":"B14", "port":"B", "num":"14", "functions":{}, "csv":{} },
-      ];
-    return pins
+  pins = [
+      { "name":"PH0", "sortingname":"H0", "port":"H", "num":"0", "functions":{}, "csv":{} },
+      { "name":"PH1", "sortingname":"H1", "port":"H", "num":"1", "functions":{}, "csv":{} },
+      { "name":"PH2", "sortingname":"H2", "port":"H", "num":"2", "functions":{}, "csv":{} },
+      { "name":"PB12", "sortingname":"B12", "port":"B", "num":"12", "functions":{}, "csv":{} },
+      { "name":"PB13", "sortingname":"B13", "port":"B", "num":"13", "functions":{}, "csv":{} },
+      { "name":"PB14", "sortingname":"B14", "port":"B", "num":"14", "functions":{}, "csv":{} },
+      { "name":"PD1", "sortingname":"D1", "port":"D", "num":"1", "functions":{"SPI1_SCK":0}, "csv":{}},
+      { "name":"PD14", "sortingname":"D14", "port":"D", "num":"14", "functions":{"SPI1_MISO":0}, "csv":{}},
+      { "name":"PG8", "sortingname":"G8", "port":"G", "num":"8", "functions":{"SPI1_MOSI":0}, "csv":{}}
+    ];
+  return pins
 
 board_css = """
 """;

--- a/targets/pic32mzef/framework/system/ports/src/sys_ports_static.c
+++ b/targets/pic32mzef/framework/system/ports/src/sys_ports_static.c
@@ -75,6 +75,16 @@ void SYS_PORTS_Initialize(void)
     PLIB_PORTS_ChannelChangeNoticeEnable(PORTS_ID_0, PORT_CHANNEL_C, SYS_PORT_C_CNEN);
     PLIB_PORTS_ChannelChangeNoticePullUpEnable(PORTS_ID_0, PORT_CHANNEL_C, SYS_PORT_C_CNPU);
     PLIB_PORTS_ChannelChangeNoticePullDownEnable(PORTS_ID_0, PORT_CHANNEL_C, SYS_PORT_C_CNPD);
+
+    /* PORT D Initialization */
+    PLIB_PORTS_OpenDrainEnable(PORTS_ID_0, PORT_CHANNEL_D, SYS_PORT_G_ODC);
+    PLIB_PORTS_Write( PORTS_ID_0, PORT_CHANNEL_D,  SYS_PORT_G_LAT);
+    PLIB_PORTS_DirectionOutputSet( PORTS_ID_0, PORT_CHANNEL_D,  SYS_PORT_G_TRIS ^ 0xFFFF);
+    PLIB_PORTS_ChangeNoticePerPortTurnOn(PORTS_ID_0, PORT_CHANNEL_D);
+    PLIB_PORTS_ChannelModeSelect(PORTS_ID_0, PORT_CHANNEL_D, SYS_PORT_G_ANSEL ^ 0xFFFF, PORTS_PIN_MODE_DIGITAL);
+    PLIB_PORTS_ChannelChangeNoticeEnable(PORTS_ID_0, PORT_CHANNEL_D, SYS_PORT_G_CNEN);
+    PLIB_PORTS_ChannelChangeNoticePullUpEnable(PORTS_ID_0, PORT_CHANNEL_D, SYS_PORT_G_CNPU);
+    PLIB_PORTS_ChannelChangeNoticePullDownEnable(PORTS_ID_0, PORT_CHANNEL_D, SYS_PORT_G_CNPD);
     
     /* PORT G Initialization */
     PLIB_PORTS_OpenDrainEnable(PORTS_ID_0, PORT_CHANNEL_G, SYS_PORT_G_ODC);
@@ -103,6 +113,13 @@ void SYS_PORTS_Initialize(void)
     /* PPS Output Remapping */
     PLIB_PORTS_RemapOutput(PORTS_ID_0, OUTPUT_FUNC_U2TX, OUTPUT_PIN_RPB14 );
 
+    /* PPS Remap for SPI */
+    
+    /* PPS Input Remapping */
+    PLIB_PORTS_RemapInput(PORTS_ID_0, INPUT_FUNC_SDI1, INPUT_PIN_RPD14 );
+
+    /* PPS Output Remapping */
+    PLIB_PORTS_RemapOutput(PORTS_ID_0, OUTPUT_FUNC_SDO1, OUTPUT_PIN_RPG8 );
     
 }
 

--- a/targets/pic32mzef/system_definitions.h
+++ b/targets/pic32mzef/system_definitions.h
@@ -59,7 +59,9 @@ SUBSTITUTE GOODS, TECHNOLOGY, SERVICES, OR ANY CLAIMS BY THIRD PARTIES
 #include "driver/usart/drv_usart_static.h"
 #include "peripheral/usart/plib_usart.h"
 #include "peripheral/int/plib_int.h"
+#include "peripheral/spi/plib_spi.h"
 #include "system/ports/sys_ports.h"
+#include "driver/spi/drv_spi_static.h"
 
 
 #include "main.h"

--- a/targets/pic32mzef/system_init.c
+++ b/targets/pic32mzef/system_init.c
@@ -205,6 +205,7 @@ void SYS_Initialize ( void* data )
 
     /* Initialize Drivers */
     DRV_USART0_Initialize();
+    DRV_SPI0_Initialize();
 
     /* Initialize System Services */
     SYS_INT_Initialize();  


### PR DESCRIPTION
Enabled initial support for SPI1:
- used the following pin mapping:
  SDI1 -> RPD14 (J10 pin 44 starter kit i/o exp board)
  SDO1-> RPG8 (J10 pin 35 starter kit i/o exp board)
- basic tests with SPI1.send(<Integer>) pass
